### PR TITLE
Landing url replacement

### DIFF
--- a/publisher/README.md
+++ b/publisher/README.md
@@ -40,7 +40,9 @@ Now initialize Moloco SDK using the provided ad unit ID.
       country_iso: "kr",
       width: 640,
       height: 100,
-      os: "android"
+      os: "android",
+      use_redirect_url: false, // default: false.
+      isLegacy: false, // default: true.
     }); 
   </script>
 ```

--- a/publisher/README.md
+++ b/publisher/README.md
@@ -41,8 +41,8 @@ Now initialize Moloco SDK using the provided ad unit ID.
       width: 640,
       height: 100,
       os: "android",
-      use_redirect_url: false, // default: false.
-      isLegacy: false, // default: true.
+      use_direct_landing: true, // default: false.
+      use_endpoint_v1: true, // default: false.
     }); 
   </script>
 ```

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -70,9 +70,9 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
           if (!context.useEndpointV1) {
               context.renderAd(xhr.responseText);
           } else {
-              bannerAd = JSON.parse(xhr.responseText);
+              const bannerAd = JSON.parse(xhr.responseText);
               if (context.useDirectLanding) {
-                  context.renderAdWithRedirectUrl(bannerAd);
+                  context.renderAdWithDirectLanding(bannerAd);
               } else {
                   context.renderAd(bannerAd.html);
               }
@@ -93,7 +93,7 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
   }
 }
 
-MolocoSDK.prototype.renderAdWithRedirectUrl = function (bannerAd) {
+MolocoSDK.prototype.renderAdWithDirectLanding = function (bannerAd) {
   this.renderAd(bannerAd.html);
 
   const atag = document.getElementById("molocoads_link");
@@ -102,13 +102,13 @@ MolocoSDK.prototype.renderAdWithRedirectUrl = function (bannerAd) {
 
   if(atag.addEventListener) {
     atag.addEventListener('click', function(){
-      let xhr = new XMLHttpRequest();
+      const xhr = new XMLHttpRequest();
       xhr.open("GET", originClickUrl, true);
       xhr.send();
     });
   } else if(link.attachEvent) {
     atag.attachEvent('onclick', function(){
-      let xhr = new XMLHttpRequest();
+      const xhr = new XMLHttpRequest();
       xhr.open("GET", originClickUrl, true);
       xhr.send();
     });

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -28,7 +28,8 @@ function constructNativeAdDiv(nativeAd, nativeAdDiv) {
 }
 
 var MolocoSDK = function (data) {
-  this.endpoint = "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
+  this.isLegacy = (data["isLegacy"] != null) ? data["isLegacy"] : true;
+  this.endpoint = (this.isLegacy === true) ? "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1" : "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
   this.adUnit = data["ad_unit"];
   this.adType = data["ad_type"];
   this.containerId = data["container_id"];
@@ -65,8 +66,12 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
     if (this.readyState === 4 && this.status === 200) {
       switch (context.adType) {
         case AdType.BANNER:
-          bannerAd = JSON.parse(xhr.responseText);
-          context.renderAd(bannerAd.html);
+          if (context.isLegacy) {
+              context.renderAd(xhr.responseText);
+          } else {
+              bannerAd = JSON.parse(xhr.responseText);
+              context.renderAd(bannerAd.html);
+          }
           break;
         case AdType.NATIVE:
           let nativeAd;

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -28,7 +28,7 @@ function constructNativeAdDiv(nativeAd, nativeAdDiv) {
 }
 
 var MolocoSDK = function (data) {
-  this.isLegacy = (data["isLegacy"] != null) ? data["isLegacy"] : true;
+  this.isLegacy = (data["is_legacy"] != null) ? data["is_legacy"] : true;
   this.useRedirectUrl = data["use_redirect_url"] || false;
   this.endpoint = (this.isLegacy === true) ? "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1" : "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
   this.adUnit = data["ad_unit"];

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -100,9 +100,19 @@ MolocoSDK.prototype.renderAdWithRedirectUrl = function (bannerAd) {
   const originClickUrl = atag.href;
   atag.href = bannerAd.finallandingurl;
 
-  let xhr = new XMLHttpRequest();
-  xhr.open("GET", originClickUrl, true);
-  xhr.send();
+  if(atag.addEventListener) {
+    atag.addEventListener('click', function(){
+      let xhr = new XMLHttpRequest();
+      xhr.open("GET", originClickUrl, true);
+      xhr.send();
+    });
+  } else if(link.attachEvent) {
+    atag.attachEvent('onclick', function(){
+      let xhr = new XMLHttpRequest();
+      xhr.open("GET", originClickUrl, true);
+      xhr.send();
+    });
+  }
 }
 
 // Render ad received from Moloco.

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -28,7 +28,7 @@ function constructNativeAdDiv(nativeAd, nativeAdDiv) {
 }
 
 var MolocoSDK = function (data) {
-  this.endpoint = "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1";
+  this.endpoint = "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
   this.adUnit = data["ad_unit"];
   this.adType = data["ad_type"];
   this.containerId = data["container_id"];
@@ -65,7 +65,8 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
     if (this.readyState === 4 && this.status === 200) {
       switch (context.adType) {
         case AdType.BANNER:
-          context.renderAd(xhr.responseText);
+          bannerAd = JSON.parse(xhr.responseText);
+          context.renderAd(bannerAd.html);
           break;
         case AdType.NATIVE:
           let nativeAd;

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -28,9 +28,9 @@ function constructNativeAdDiv(nativeAd, nativeAdDiv) {
 }
 
 var MolocoSDK = function (data) {
-  this.isLegacy = (data["is_legacy"] != null) ? data["is_legacy"] : true;
-  this.useRedirectUrl = data["use_redirect_url"] || false;
-  this.endpoint = (this.isLegacy === true) ? "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1" : "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
+  this.useEndpointV1 = data["use_endpoint_v1"] || false;
+  this.useDirectLanding = data["use_direct_landing"] || false;
+  this.endpoint = (!this.useEndpointV1) ? "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1" : "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
   this.adUnit = data["ad_unit"];
   this.adType = data["ad_type"];
   this.containerId = data["container_id"];
@@ -67,11 +67,11 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
     if (this.readyState === 4 && this.status === 200) {
       switch (context.adType) {
         case AdType.BANNER:
-          if (context.isLegacy) {
+          if (!context.useEndpointV1) {
               context.renderAd(xhr.responseText);
           } else {
               bannerAd = JSON.parse(xhr.responseText);
-              if (context.useRedirectUrl) {
+              if (context.useDirectLanding) {
                   context.renderAdWithRedirectUrl(bannerAd);
               } else {
                   context.renderAd(bannerAd.html);

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -48,6 +48,10 @@ var MolocoSDK = function (data) {
 MolocoSDK.prototype.requestAd = function (adDiv) {
   const orientation = window.innerWidth > window.innerHeight ? "l" : "p";
   let url = this.endpoint + "&id=" + this.adUnit + "&udid=ifa:" + this.idfa + "&bundle=" + this.bundle + "&iso=" + this.country + "&w=" + this.width + "&h=" + this.height + "&o=" + orientation + "&ufid=" + uuidv4() + "&x=" + this.extra + "&os=" + this.os;
+  if (this.useEndpointV1) {
+    url = this.endpoint + "&adid=" + this.idfa + "&id=" + this.adUnit + "&productid=" + this.bundle + "&country=" + this.country + "&o=" + orientation + "&x=" + this.extra + "&os=" + this.os;
+  }
+
   if (this.adType === AdType.NATIVE) {
     url = url + "&assets=title%2Ctext%2Ciconimage%2Cmainimage%2Cctatext";
   }

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -29,6 +29,7 @@ function constructNativeAdDiv(nativeAd, nativeAdDiv) {
 
 var MolocoSDK = function (data) {
   this.isLegacy = (data["isLegacy"] != null) ? data["isLegacy"] : true;
+  this.useRedirectUrl = data["use_redirect_url"] || false;
   this.endpoint = (this.isLegacy === true) ? "//adservfnt-asia.adsmoloco.com/adserver?mobile_web=1" : "//adservfnt-asia.adsmoloco.com/adserver/v1?mobile_web=1";
   this.adUnit = data["ad_unit"];
   this.adType = data["ad_type"];
@@ -70,7 +71,11 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
               context.renderAd(xhr.responseText);
           } else {
               bannerAd = JSON.parse(xhr.responseText);
-              context.renderAd(bannerAd.html);
+              if (context.useRedirectUrl) {
+                  context.renderAdWithRedirectUrl(bannerAd);
+              } else {
+                  context.renderAd(bannerAd.html);
+              }
           }
           break;
         case AdType.NATIVE:
@@ -86,6 +91,18 @@ MolocoSDK.prototype.requestAd = function (adDiv) {
       }
     }
   }
+}
+
+MolocoSDK.prototype.renderAdWithRedirectUrl = function (bannerAd) {
+  this.renderAd(bannerAd.html);
+
+  const atag = document.getElementById("molocoads_link");
+  const originClickUrl = atag.href;
+  atag.href = bannerAd.finallandingurl;
+
+  let xhr = new XMLHttpRequest();
+  xhr.open("GET", originClickUrl, true);
+  xhr.send();
 }
 
 // Render ad received from Moloco.

--- a/publisher/moloco.js
+++ b/publisher/moloco.js
@@ -106,12 +106,6 @@ MolocoSDK.prototype.renderAdWithDirectLanding = function (bannerAd) {
       xhr.open("GET", originClickUrl, true);
       xhr.send();
     });
-  } else if(link.attachEvent) {
-    atag.attachEvent('onclick', function(){
-      const xhr = new XMLHttpRequest();
-      xhr.open("GET", originClickUrl, true);
-      xhr.send();
-    });
   }
 }
 


### PR DESCRIPTION
* I added to support the new protocol which receives JSON object from the adserver. If we set `is_legacy` on an initializing phase, we could use previous protocol which returns an only HTML snippet.
* By needs of clients, I added to feature that could replace a redirect_url to URL of ad response field `finallandingurl`.
Another request will be made for an original click URL.
This feature will be enabled by an initializing phase with field `use_redirect_url`.